### PR TITLE
chore: remove original repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # node-snapdrop [![CodeQL](https://github.com/Bellisario/node-snapdrop/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Bellisario/node-snapdrop/actions/workflows/codeql-analysis.yml)
 
-Just the original [Snapdrop](https://github.com/RobinLinus/Snapdrop), with complete Node.js server.
+Just the original Snapdrop, with complete Node.js server.
+
+> [!NOTE]
+> We do not endorse any recent changes made to the original Snapdrop, sold to LimeWire & [considered badware](https://github.com/uBlockOrigin/uAssets/issues/27172) by uBlock Origin, so we removed all the links referring to it.\
+> \
+> This repository acts as a pre-LimeWire & Node.js version of the good old Snapdrop.
 
 ## Getting started
 

--- a/public/index.html
+++ b/public/index.html
@@ -14,12 +14,12 @@
     <!-- Descriptions -->
     <meta name="description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
     <meta name="keywords" content="File, Transfer, Share, Peer2Peer">
-    <meta name="author" content="RobinLinus">
+    <meta name="author" content="Giorgio Bellisario">
     <meta property="og:title" content="Snapdrop">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://snapdrop.net/">
-    <meta property="og:author" content="https://facebook.com/RobinLinus">
-    <meta name="twitter:author" content="@RobinLinus">
+    <meta property="og:url" content="https://github.com/Bellisario/node-snapdrop">
+    <meta property="og:author" content="https://github.com/Bellisario">
+    <meta name="twitter:author" content="@GiorgioBellix">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
     <meta name="og:description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
@@ -29,8 +29,8 @@
     <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
     <meta name="msapplication-TileImage" content="images/mstile-150x150.png">
     <link rel="fluid-icon" type="image/png" href="images/android-chrome-192x192.png">
-    <meta name="twitter:image" content="https://snapdrop.net/images/twitter-stream.jpg">
-    <meta property="og:image" content="https://snapdrop.net/images/twitter-stream.jpg">
+    <meta name="twitter:image" content="images/twitter-stream.jpg">
+    <meta property="og:image" content="images/twitter-stream.jpg">
     <!-- Resources -->
     <link rel="stylesheet" type="text/css" href="styles.css">
     <link rel="manifest" href="manifest.json">
@@ -140,24 +140,24 @@
                 <use xlink:href="#wifi-tethering" />
             </svg>
             <h1>Snapdrop</h1>
-            <div class="font-subheading">The easiest way to transfer files across devices<div style="font-size:10px;">Modified Node version by <a href="https://github.com/Bellisario" target="_blank">Bellisario</a></div></div>
+            <div class="font-subheading">The easiest way to transfer files across devices<div style="font-size:0.7em;">Node.js version based on the original Snapdrop</div></div>
             <div class="row">
-                <a class="icon-button" target="_blank" href="https://github.com/RobinLinus/snapdrop" title="Snapdrop on Github" rel="noreferrer">
+                <a class="icon-button" target="_blank" href="https://github.com/Bellisario/node-snapdrop" title="node-snapdrop on Github" rel="noreferrer">
                     <svg class="icon">
                         <use xlink:href="#github" />
                     </svg>
                 </a>
-                <a class="icon-button" target="_blank" href="https://www.paypal.com/donate?hosted_button_id=FTP9DXUR7LA7Q" title="Help cover the server costs!" rel="noreferrer">
+                <a class="icon-button" target="_blank" href="https://github.com/sponsors/Bellisario" title="Support the developer" rel="noreferrer">
                     <svg class="icon">
                         <use xlink:href="#monetarization" />
                     </svg>
                 </a>
-                <a class="icon-button" target="_blank" href="https://twitter.com/intent/tweet?text=https://snapdrop.net%20by%20@robin_linus%20&" title="Tweet about Snapdrop" rel="noreferrer">
+                <a class="icon-button" target="_blank" href="https://twitter.com/intent/tweet?text=node-snapdrop%20is%20awesome!%0A%0Ahttps%3A%2F%2Fgithub.com%2FBellisario%2Fnode-snapdrop" title="Tweet about node-snapdrop" rel="noreferrer">
                     <svg class="icon">
                         <use xlink:href="#twitter" />
                     </svg>
                 </a>
-                <a class="icon-button" target="_blank" href="https://github.com/RobinLinus/snapdrop/blob/master/docs/faq.md" title="Frequently asked questions" rel="noreferrer">
+                <a class="icon-button" target="_blank" href="https://github.com/Bellisario/node-snapdrop/issues" title="Get help" rel="noreferrer">
                     <svg class="icon">
                         <use xlink:href="#help-outline" />
                     </svg>


### PR DESCRIPTION
Closes #83.

The original Snapdrop has been sold to LimeWire and it's now also [considered badware](https://github.com/uBlockOrigin/uAssets/issues/27172) by uBlock Origin.

This pull request removes all the links referring to the Snapdrop repository and links them to this repository instead.\
Also README got updated to provide useful information of why this happened.