### PR TITLE
fix(codeql): polynomial regex use on uncontrolled data

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class Peer {
 
     _setIP(request) {
         if (request.headers['x-forwarded-for']) {
-            this.ip = request.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
+            this.ip = request.headers['x-forwarded-for'].split(',')[0].trim();
         } else {
             this.ip = request.connection.remoteAddress;
         }


### PR DESCRIPTION
From CodeQL:

> This regular expression that depends on a user-provided value may run slow on strings with many repetitions of ' '. 